### PR TITLE
Add build CI and kernel sanity test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y bmake
+      - name: Run make (dry run)
+        run: bmake -C usr/src -n
+      - name: Run sanity tests
+        run: tests/test_kernel.sh

--- a/tests/test_kernel.sh
+++ b/tests/test_kernel.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+# Determine repository root as the parent directory of this script
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Perform a dry-run build to ensure makefiles parse correctly
+bmake -C usr/src -n > /dev/null
+
+# Check that the kernel image exists
+if [ ! -f 386bsd ]; then
+  echo "Kernel image 386bsd not found" >&2
+  exit 1
+fi
+
+echo "Kernel image present: $(ls -l 386bsd)"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to parse the build with `bmake`
- add a basic test verifying the prebuilt `386bsd` kernel image

## Testing
- `bmake -C usr/src -n | head -n 3`
- `tests/test_kernel.sh`


------
https://chatgpt.com/codex/tasks/task_e_688af6777e748331b38afcf164963f7a