### PR TITLE
Add code analysis tooling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 2
+ColumnLimit: 80

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: 'clang-diagnostic-*,bugprone-*,performance-*,readability-*,portability-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: none

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,4 +4,6 @@
 .. toctree::
    :maxdepth: 2
 
+   tooling
+
 .. doxygenfile:: proc.c

--- a/docs/tooling.rst
+++ b/docs/tooling.rst
@@ -1,0 +1,16 @@
+Code Analysis Tooling
+=====================
+
+The following utilities assist in understanding the aging 386BSD codebase:
+
+* **cloc** – identifies programming languages present in the tree.
+* **clang-tidy** – parses C sources in C89 mode to flag K&R style and
+  other dialect issues.
+* **cppcheck** – detects common defects that contribute to technical debt.
+* **clang-format** – enforces consistent C formatting.
+* **bear** – generates *compile_commands.json* for large-scale analysis
+  with ``clang-tidy``.
+
+Example usage is provided by ``scripts/analyze_code.sh`` which gathers
+language statistics and runs both ``cppcheck`` and ``clang-tidy`` on a
+sample kernel file.

--- a/scripts/analyze_code.sh
+++ b/scripts/analyze_code.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# analyze_code.sh - static analysis toolkit for the 386BSD source tree
+#
+# This script demonstrates language statistics, dialect checks, and
+# basic static analysis with tools configured for C89 semantics. The
+# goal is to surface legacy K&R constructs and other technical debt.
+#
+set -eu
+
+# Repository root
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+printf '%s\n' '== Language statistics (cloc) =='
+cloc usr/src | head -n 20
+
+printf '%s\n' '\n== cppcheck (C89 dialect) =='
+cppcheck --std=c89 usr/src/kernel/route/radix.c 2> cppcheck.log
+# Display tail of log for brevity
+if [ -s cppcheck.log ]; then
+  tail -n 20 cppcheck.log
+fi
+
+printf '%s\n' '\n== clang-tidy (C89 dialect) =='
+clang-tidy usr/src/kernel/route/radix.c -- -std=c89 > clang_tidy.log || true
+if [ -s clang_tidy.log ]; then
+  tail -n 20 clang_tidy.log
+fi

--- a/setup.md
+++ b/setup.md
@@ -61,8 +61,32 @@ The command currently warns about the deprecated `http-proxy` environment config
 - `doxygen-latex` – PDF outputs.
 - `sphinx-autobuild` – live-reloading docs during authoring.
 - `clang-format` – consistent C/C++ formatting.
-- `cppcheck` – static analysis for C.
 - `qemu-system-i386` – emulate the 386BSD kernel image.
+
+## Code analysis tooling
+
+Install language and static analysis helpers:
+
+```bash
+sudo apt-get install -y \
+  cloc \
+  cppcheck \
+  clang-tidy \
+  bear
+
+# version checks
+cloc --version
+cppcheck --version
+clang-tidy --version
+bear --version
+```
+
+- **cloc** – reports which languages and file counts are present.
+- **clang-tidy** – checks dialect compliance (e.g., K&R vs C89) and style issues.
+- **cppcheck** – finds common bugs and sources of technical debt.
+- **bear** – generates `compile_commands.json` to enable project-wide `clang-tidy` runs.
+
+A convenience script `scripts/analyze_code.sh` demonstrates these tools.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- Configure clang-format and clang-tidy for consistent C89-aware analysis
- Add analyze_code.sh to run cloc, cppcheck, and clang-tidy on kernel sources
- Document analysis workflow in setup guide and Sphinx docs

## Testing
- `scripts/analyze_code.sh`
- `tests/test_kernel.sh`
- `tests/test_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6892ab1ca6948331aae8dc1b52b3022c

## Summary by Sourcery

Add static code analysis tooling and documentation for the 386BSD source tree

New Features:
- Include analyze_code.sh script to run cloc, cppcheck, and clang-tidy on the kernel sources
- Add .clang-format and .clang-tidy configuration files for consistent C89-aware checks

Enhancements:
- Configure analysis tools to enforce C89 dialect compliance and consistent formatting

Documentation:
- Document the code analysis workflow in setup.md and add a dedicated tooling.rst page in the Sphinx docs