### PR TITLE
Add Clang/LLD i386 ELF cross-compilation scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ tmp/
 # Miscellaneous
 # -----------------------------
 tags       # ctags/etags index files
+# Cross-compilation sysroot skeleton
+!sysroots/
+!sysroots/386bsd-elf/
+!sysroots/386bsd-elf/.gitkeep

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Top-level CMake entry point for 386BSD. At present the build
-# system is used solely for documentation generation and does not
-# attempt to replace the historical makefiles.
-project(386BSD NONE)
+# Top-level CMake entry point for 386BSD. Historically this project
+# only drove documentation via CMake, but optional test targets are
+# provided to validate cross-compilation infrastructure.
+project(386BSD C)
 
-add_subdirectory(docs)
+option(BUILD_DOCS "Build documentation with Doxygen and Sphinx" ON)
+option(BUILD_TESTS "Build auxiliary test binaries" ON)
+
+if(BUILD_DOCS)
+  add_subdirectory(docs)
+endif()
+
+if(BUILD_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,23 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 25, "patch": 0},
+  "configurePresets": [
+    {
+      "name": "clang-elf",
+      "displayName": "Clang i386-ELF",
+      "generator": "Ninja",
+      "binaryDir": "build/clang-elf",
+      "toolchainFile": "cmake/toolchains/clang-i386-elf.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_DOCS": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    {"name": "clang-elf", "configurePreset": "clang-elf"}
+  ],
+  "testPresets": [
+    {"name": "clang-elf", "configurePreset": "clang-elf"}
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+# Top-level Makefile placeholder
+ifeq ($(PROFILE),clang-elf)
+  include mk/clang-elf.mk
+endif
+
+.PHONY: help
+help:
+@echo "Use PROFILE=clang-elf to enable the Clang/LLD cross toolchain."

--- a/cmake/toolchains/clang-i386-elf.cmake
+++ b/cmake/toolchains/clang-i386-elf.cmake
@@ -1,0 +1,40 @@
+# ---------------------------------------------------------------------------
+# Clang/LLD cross-compilation toolchain for 386BSD userland.
+#
+# This toolchain teaches CMake how to emit 32-bit i386 ELF objects using
+# Clang and LLD.  The configuration is intentionally explicit so that
+# developers are not surprised by implicit defaults drawn from the build
+# host.  It assumes that an external script (see scripts/make-sysroot.sh)
+# has produced a self-contained sysroot containing the 386BSD headers and
+# a bootstrap libc.a archive.
+# ---------------------------------------------------------------------------
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR i386)
+
+set(TGT "i386-unknown-elf")
+
+# Compilers ---------------------------------------------------------------
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_COMPILER_TARGET "${TGT}")
+set(CMAKE_ASM_COMPILER clang)
+set(CMAKE_ASM_COMPILER_TARGET "${TGT}")
+set(CMAKE_AR llvm-ar)
+set(CMAKE_RANLIB llvm-ranlib)
+set(CMAKE_LINKER ld.lld)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# Sysroot handling -------------------------------------------------------
+if(NOT DEFINED CMAKE_SYSROOT)
+  if(DEFINED ENV{SYSROOT})
+    set(CMAKE_SYSROOT "$ENV{SYSROOT}")
+  else()
+    message(FATAL_ERROR "CMAKE_SYSROOT or $SYSROOT must be set (e.g. sysroots/386bsd-elf)")
+  endif()
+endif()
+
+# Compiler and linker flags ----------------------------------------------
+set(COMMON_C_FLAGS "-ffreestanding -fno-builtin -fno-omit-frame-pointer -fno-stack-protector -fno-asynchronous-unwind-tables -m32 -march=i386 -mno-sse -mno-sse2 -mno-mmx -msoft-float -fuse-ld=lld --sysroot=${CMAKE_SYSROOT}")
+set(CMAKE_C_FLAGS_INIT "${COMMON_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-static --sysroot=${CMAKE_SYSROOT} -Wl,-m,elf_i386 -nostdlib")
+set(CMAKE_TRY_COMPILE_CONFIGURATION Release)

--- a/docs/sysroot.md
+++ b/docs/sysroot.md
@@ -1,0 +1,41 @@
+# 386BSD Cross Sysroot Setup
+
+This document captures the tooling and steps used to assemble the i386 ELF
+sysroot required for cross-compiling legacy 386BSD userland with modern LLVM
+components.
+
+## Host Packages
+
+The development environment relies on the following Ubuntu 24.04 packages:
+
+```
+clang lld llvm cmake ninja-build python3 python3-pip rsync \
+  build-essential ripgrep doxygen graphviz pandoc
+```
+
+These can be installed via:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clang lld llvm cmake ninja-build \
+  python3 python3-pip rsync build-essential ripgrep \
+  doxygen graphviz pandoc
+```
+
+## Sysroot Builder
+
+The script `scripts/make-sysroot.sh` copies the repository's header sources into
+`sysroots/386bsd-elf` and constructs a bootstrap `libc.a`.  Header installation
+filters out broken `nonstd/` symlinks and verifies the presence of
+`sys/cdefs.h` and `machine/ansi.h` to guarantee a minimal, freestanding
+environment for Clang.
+
+Invoke the script as:
+
+```bash
+SYSROOT=$PWD/sysroots/386bsd-elf ./scripts/make-sysroot.sh
+```
+
+On success a static `libc.a` will be produced at `$SYSROOT/usr/lib/` and the
+full header tree will reside under `$SYSROOT/usr/include/`.
+

--- a/mk/clang-elf.mk
+++ b/mk/clang-elf.mk
@@ -1,0 +1,32 @@
+# ---------------------------------------------------------------------------
+# mk/clang-elf.mk
+#
+# BSD make profile that exposes a Clang/LLD based cross toolchain targeting
+# 32-bit i386 System V ELF.  The variables exported here are intentionally
+# minimalistic so legacy makefiles can opt-in without collateral changes.
+#
+# Usage:
+#   make PROFILE=clang-elf <target>
+# ---------------------------------------------------------------------------
+
+SYSROOT?=$(CURDIR)/sysroots/386bsd-elf
+export SYSROOT
+
+export CC=clang
+export AS=clang
+export AR=llvm-ar
+export RANLIB=llvm-ranlib
+export LD=ld.lld
+
+COMMON_CFLAGS= \
+  -ffreestanding -fno-builtin -fno-omit-frame-pointer -fno-stack-protector \
+  -fno-asynchronous-unwind-tables -m32 -march=i386 -mno-sse -mno-sse2 \
+  -mno-mmx -msoft-float --sysroot=$(SYSROOT)
+WARN_CFLAGS= \
+  -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
+export CFLAGS?= -O2 $(COMMON_CFLAGS) $(WARN_CFLAGS)
+
+export CPPFLAGS?= -nostdinc -isystem $(SYSROOT)/usr/include
+export LDFLAGS?= -static --sysroot=$(SYSROOT) -m elf_i386 -nostdlib
+
+export LIBC?=$(SYSROOT)/usr/lib/libc.a

--- a/scripts/ccwrap
+++ b/scripts/ccwrap
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# ccwrap -- hermetic Clang invocation wrapper
+set -euo pipefail
+: "${SYSROOT:?set SYSROOT first}"
+exec clang --target=i386-unknown-elf --sysroot="$SYSROOT" \
+  -ffreestanding -fno-builtin -m32 -march=i386 -mno-sse -mno-sse2 -mno-mmx \
+  -msoft-float -fno-omit-frame-pointer -fno-stack-protector \
+  -fno-asynchronous-unwind-tables "$@"

--- a/scripts/ccwrap.md
+++ b/scripts/ccwrap.md
@@ -1,0 +1,14 @@
+# ccwrap
+
+Compiler wrapper enforcing i386 ELF cross flags.
+
+```bash
+#!/usr/bin/env bash
+# ccwrap -- hermetic Clang invocation wrapper
+set -euo pipefail
+: "${SYSROOT:?set SYSROOT first}"
+exec clang --target=i386-unknown-elf --sysroot="$SYSROOT" \
+  -ffreestanding -fno-builtin -m32 -march=i386 -mno-sse -mno-sse2 -mno-mmx \
+  -msoft-float -fno-omit-frame-pointer -fno-stack-protector \
+  -fno-asynchronous-unwind-tables "$@"
+```

--- a/scripts/make-sysroot.sh
+++ b/scripts/make-sysroot.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# make-sysroot.sh -- construct a Clang-friendly 386BSD sysroot
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.."; pwd)"
+SYSROOT="${SYSROOT:-$ROOT/sysroots/386bsd-elf}"
+
+HDR_SRC=(
+  "$ROOT/usr/include"
+  "$ROOT/usr/src/include"
+  "$ROOT/usr/src/lib/libc/include"
+)
+LIBC_DIR="$ROOT/usr/src/lib/libc"
+
+echo "[*] Creating sysroot at: $SYSROOT"
+mkdir -p "$SYSROOT/usr/include" "$SYSROOT/usr/lib"
+
+found=0
+for d in "${HDR_SRC[@]}"; do
+  if [ -d "$d" ]; then
+    echo "[*] Installing headers from $d"
+    rsync -aL --exclude 'nonstd/**' "$d"/ "$SYSROOT/usr/include"/ || true
+    found=1
+  fi
+done
+if [ "$found" -eq 0 ]; then
+  echo "!! Could not locate 386BSD headers. Check paths in make-sysroot.sh" >&2
+  exit 1
+fi
+
+for hdr in sys/cdefs.h machine/ansi.h; do
+  if [ ! -f "$SYSROOT/usr/include/$hdr" ]; then
+    echo "!! Missing $hdr in sysroot" >&2
+    exit 1
+  fi
+done
+
+# Avoid mutating the source tree during sysroot generation
+#if [ -f "$ROOT/scripts/relativize_symlinks.py" ]; then
+#  (cd "$ROOT" && python3 scripts/relativize_symlinks.py)
+#fi
+
+export CC=clang
+export AR=llvm-ar
+export RANLIB=llvm-ranlib
+export SYSROOT
+
+CFLAGS="-ffreestanding -fno-builtin -m32 -march=i386 -mno-sse -mno-sse2 -mno-mmx -msoft-float \
+        -nostdinc -isystem $SYSROOT/usr/include -O2 -fno-omit-frame-pointer -fno-stack-protector"
+LDFLAGS="-static --sysroot=$SYSROOT -m elf_i386 -nostdlib"
+
+WORK="$(mktemp -d "$ROOT/.libc-build.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+find "$LIBC_DIR" -type f -name '*.c' > "$WORK/files.lst" || true
+
+if [ ! -s "$WORK/files.lst" ]; then
+  echo "!! No libc sources found at $LIBC_DIR; adjust make-sysroot.sh" >&2
+  exit 1
+fi
+
+while IFS= read -r f; do
+  out="$WORK/$(echo "$f" | sed 's/[^A-Za-z0-9_]/_/g').o"
+  echo "  CC $f"
+  "$CC" --target=i386-unknown-elf $CFLAGS -c "$f" -o "$out" || {
+    echo "!! Failed compiling $f"; exit 1; }
+done < "$WORK/files.lst"
+
+echo "[*] Archiving libc.a"
+"$AR" rcs "$SYSROOT/usr/lib/libc.a" "$WORK"/*.o
+"$RANLIB" "$SYSROOT/usr/lib/libc.a"
+
+echo "[✓] Sysroot ready: $SYSROOT"

--- a/scripts/make-sysroot.sh.md
+++ b/scripts/make-sysroot.sh.md
@@ -1,0 +1,79 @@
+# make-sysroot.sh
+
+The following shell script assembles a 386BSD cross-compilation sysroot.
+
+```bash
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# make-sysroot.sh -- construct a Clang-friendly 386BSD sysroot
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.."; pwd)"
+SYSROOT="${SYSROOT:-$ROOT/sysroots/386bsd-elf}"
+
+HDR_SRC=(
+  "$ROOT/usr/include"
+  "$ROOT/usr/src/include"
+  "$ROOT/usr/src/lib/libc/include"
+)
+LIBC_DIR="$ROOT/usr/src/lib/libc"
+
+echo "[*] Creating sysroot at: $SYSROOT"
+mkdir -p "$SYSROOT/usr/include" "$SYSROOT/usr/lib"
+
+found=0
+for d in "${HDR_SRC[@]}"; do
+  if [ -d "$d" ]; then
+    echo "[*] Installing headers from $d"
+    rsync -a --delete --exclude 'nonstd/**' "$d"/ "$SYSROOT/usr/include"/ || true
+    found=1
+  fi
+done
+if [ "$found" -eq 0 ]; then
+  echo "!! Could not locate 386BSD headers. Check paths in make-sysroot.sh" >&2
+  exit 1
+fi
+
+for hdr in sys/cdefs.h machine/ansi.h; do
+  if [ ! -f "$SYSROOT/usr/include/$hdr" ]; then
+    echo "!! Missing $hdr in sysroot" >&2
+    exit 1
+  fi
+done
+
+if [ -f "$ROOT/scripts/relativize_symlinks.py" ]; then
+  (cd "$ROOT" && python3 scripts/relativize_symlinks.py)
+fi
+
+export CC=clang
+export AR=llvm-ar
+export RANLIB=llvm-ranlib
+export SYSROOT
+
+CFLAGS="-ffreestanding -fno-builtin -m32 -march=i386 -mno-sse -mno-sse2 -mno-mmx -msoft-float \
+        -nostdinc -isystem $SYSROOT/usr/include -O2 -fno-omit-frame-pointer -fno-stack-protector"
+LDFLAGS="-static --sysroot=$SYSROOT -m elf_i386 -nostdlib"
+
+WORK="$(mktemp -d "$ROOT/.libc-build.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+find "$LIBC_DIR" -type f -name '*.c' > "$WORK/files.lst" || true
+
+if [ ! -s "$WORK/files.lst" ]; then
+  echo "!! No libc sources found at $LIBC_DIR; adjust make-sysroot.sh" >&2
+  exit 1
+fi
+
+while IFS= read -r f; do
+  out="$WORK/$(echo "$f" | sed 's/[^A-Za-z0-9_]/_/g').o"
+  echo "  CC $f"
+  "$CC" --target=i386-unknown-elf $CFLAGS -c "$f" -o "$out" || {
+    echo "!! Failed compiling $f"; exit 1; }
+done < "$WORK/files.lst"
+
+echo "[*] Archiving libc.a"
+"$AR" rcs "$SYSROOT/usr/lib/libc.a" "$WORK"/*.o
+"$RANLIB" "$SYSROOT/usr/lib/libc.a"
+
+echo "[✓] Sysroot ready: $SYSROOT"
+```

--- a/scripts/scan-includes.py
+++ b/scripts/scan-includes.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Recursively scan source files for #include directives."""
+from __future__ import annotations
+
+import collections
+import os
+import re
+import sys
+from typing import DefaultDict, Set
+
+INC_RE = re.compile(r'^\s*#\s*include\s*[<"]([^">]+)[">]')
+
+def walk_sources(root: str) -> DefaultDict[str, Set[str]]:
+    graph: DefaultDict[str, Set[str]] = collections.defaultdict(set)
+    for dirpath, _, files in os.walk(root):
+        for name in files:
+            if not name.endswith(('.c', '.h', '.S', '.s')):
+                continue
+            path = os.path.join(dirpath, name)
+            try:
+                with open(path, 'r', errors='ignore') as fh:
+                    for line in fh:
+                        m = INC_RE.match(line)
+                        if m:
+                            graph[path].add(m.group(1))
+            except OSError:
+                pass
+    return graph
+
+def main(argv: list[str]) -> int:
+    root = argv[1] if len(argv) > 1 else '.'
+    graph = walk_sources(root)
+    for src in sorted(graph):
+        for hdr in sorted(graph[src]):
+            print(f"{src} -> {hdr}")
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Aggregate test targets. Additional test suites should add their
+# own subdirectories under this location.
+add_subdirectory(smoke)

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Static hello world stub for toolchain smoke testing. The
+# toolchain file supplies the cross-compilation and linker flags.
+add_executable(hello hello.c)
+
+# Produce an ELF binary with a distinctive suffix to avoid
+# confusion with host executables.
+set_target_properties(hello PROPERTIES OUTPUT_NAME "hello.elf")

--- a/tests/smoke/hello.c
+++ b/tests/smoke/hello.c
@@ -1,0 +1,6 @@
+/* Minimal static ELF smoke test. */
+__attribute__((noreturn)) void _start(void) {
+    for (;;) {
+        __asm__ __volatile__("hlt");
+    }
+}

--- a/usr/src/include/machine/ansi.h
+++ b/usr/src/include/machine/ansi.h
@@ -1,0 +1,57 @@
+/*-
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ansi.h	7.1 (Berkeley) 3/9/91
+ */
+
+#ifndef	_ANSI_H_
+#define	_ANSI_H_
+
+/*
+ * Types which are fundamental to the implementation and may appear in
+ * more than one standard header are defined here.  Standard headers
+ * then use:
+ *	#ifdef	_SIZE_T_
+ *	typedef	_SIZE_T_ size_t;
+ *	#undef	_SIZE_T_
+ *	#endif
+ *
+ * Thanks, ANSI!
+ */
+#define	_CLOCK_T_	unsigned long		/* clock() */
+#define	_PTRDIFF_T_	int			/* ptr1 - ptr2 */
+#define	_SIZE_T_	unsigned int		/* sizeof() */
+#define	_TIME_T_	long			/* time() */
+#define	_VA_LIST_	char *			/* va_list */
+#define	_WCHAR_T_	unsigned short		/* wchar_t */
+
+#endif	/* _ANSI_H_ */

--- a/usr/src/include/sys/cdefs.h
+++ b/usr/src/include/sys/cdefs.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 1991 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)cdefs.h	7.7 (Berkeley) 3/2/92
+ */
+
+#ifndef	_CDEFS_H_
+#define	_CDEFS_H_
+
+#if defined(__cplusplus)
+#define	__BEGIN_DECLS	extern "C" {
+#define	__END_DECLS	};
+#else
+#define	__BEGIN_DECLS
+#define	__END_DECLS
+#endif
+
+/*
+ * The __CONCAT macro is used to concatenate parts of symbol names, e.g.
+ * with "#define OLD(foo) __CONCAT(old,foo)", OLD(foo) produces oldfoo.
+ * The __CONCAT macro is a bit tricky -- make sure you don't put spaces
+ * in between its arguments.  __CONCAT can also concatenate double-quoted
+ * strings produced by the __STRING macro, but this only works with ANSI C.
+ */
+#if defined(__STDC__) || defined(__cplusplus)
+#define	__P(protos)	protos		/* full-blown ANSI C */
+#define	__CONCAT(x,y)	x ## y
+#define	__STRING(x)	#x
+
+#else	/* !(__STDC__ || __cplusplus) */
+#define	__P(protos)	()		/* traditional C preprocessor */
+#define	__CONCAT(x,y)	x/**/y
+#define	__STRING(x)	"x"
+
+#ifdef __GNUC__
+#define	const		__const		/* GCC: ANSI C with -traditional */
+#define	inline		__inline
+#define	signed		__signed
+#define	volatile	__volatile
+
+#else	/* !__GNUC__ */
+#define	const				/* delete ANSI C keywords */
+#define	inline
+#define	signed
+#define	volatile
+#endif	/* !__GNUC__ */
+#endif	/* !(__STDC__ || __cplusplus) */
+
+/*
+ * GCC has extensions for declaring functions as `pure' (always returns
+ * the same value given the same inputs, i.e., has no external state and
+ * no side effects) and `dead' (nonreturning).  These mainly affect
+ * optimization and warnings.  Unfortunately, GCC complains if these are
+ * used under strict ANSI mode (`gcc -ansi -pedantic'), hence we need to
+ * define them only if compiling without this.
+ */
+#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#define __dead __volatile
+#define __pure __const
+#else
+#define __dead
+#define __pure
+#endif
+
+/*
+ * GCC 2 assumes alignment as needed for performance, this upsets bitfields
+ * in drivers, page tables, file formats ... Defeat this feature.
+ */
+#ifdef __GNUC__
+#if __GNUC__ >= 2
+#pragma pack(1)
+#endif
+#endif
+
+#ifdef notyet
+/*
+ * Insist that GCC 2 inline certain functions.
+ */
+#ifdef	__GNUC__
+#if __GNUC__ >= 2
+#define	memcpy	__builtin_memcpy
+#define	memset	__builtin_memset
+#define	strlen	__builtin_strlen
+#define	strcmp	__builtin_strcmp
+#endif
+#endif
+#endif
+
+#endif /* !_CDEFS_H_ */


### PR DESCRIPTION
## Summary
- add missing `sys/cdefs.h` and `machine/ansi.h` headers to the source include tree
- harden sysroot builder against broken symlinks and verify required headers; add Markdown docs for tooling
- document required Ubuntu packages and sysroot workflow in `docs/sysroot.md`

## Testing
- `sudo apt-get install -y clang lld llvm cmake ninja-build python3 python3-pip rsync build-essential ripgrep doxygen graphviz pandoc`
- `SYSROOT=$PWD/sysroots/386bsd-elf ./scripts/make-sysroot.sh` *(fails: heapsort.c implicit-int error)*
- `clang --target=i386-unknown-elf --sysroot="$PWD/sysroots/386bsd-elf" -nostdlib -static -Wl,-m,elf_i386 -o tests/smoke/hello.elf tests/smoke/hello.c`

------
https://chatgpt.com/codex/tasks/task_e_689a66abf9a08331ae3d17e96f20c223