### PR TITLE
Add JSON include audit and expand reproducible setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,13 @@ project(386BSD C)
 
 option(BUILD_DOCS "Build documentation with Doxygen and Sphinx" ON)
 option(BUILD_TESTS "Build auxiliary test binaries" ON)
+option(EXPORT_COMPILE_COMMANDS "Export compile_commands.json" ON)
+
+if(EXPORT_COMPILE_COMMANDS)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
+find_package(Python3 COMPONENTS Interpreter)
 
 if(BUILD_DOCS)
   add_subdirectory(docs)
@@ -14,4 +21,19 @@ endif()
 
 if(BUILD_TESTS)
   add_subdirectory(tests)
+endif()
+
+if(Python3_Interpreter_FOUND)
+  add_custom_target(
+    include-audit
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/scan-includes.py
+            ${CMAKE_SOURCE_DIR}/usr/src
+            -I ${CMAKE_SOURCE_DIR}/usr/include
+            -I ${CMAKE_SOURCE_DIR}/usr/src/include
+            -I ${CMAKE_SOURCE_DIR}/usr/src/lib/libc/include
+            --compile-commands ${CMAKE_BINARY_DIR}/compile_commands.json
+            --missing-only
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Audit header includes"
+  )
 endif()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 project = "386BSD"
-extensions = ["breathe"]
+extensions = ["breathe", "myst_parser"]
 
 # Breathe ties the Doxygen XML into Sphinx. The actual XML path is
 # supplied by CMake at build time via -Dbreathe_projects.386bsd.

--- a/docs/include-audit.md
+++ b/docs/include-audit.md
@@ -1,0 +1,66 @@
+# Header Audit
+
+The `scan-includes.py` utility inspects the source tree for `#include`
+statements and verifies that referenced headers exist. This helps uncover
+stale references that would otherwise surface during a build.
+
+## Usage
+
+```bash
+python3 scripts/scan-includes.py usr/src \
+  -I usr/include -I usr/src/include -I usr/src/lib/libc/include \
+  --missing-only
+```
+
+The command exits with a non-zero status if any headers are missing. Each
+reported line follows the format:
+
+```
+path/to/file.c -> sys/obsolete.h [MISSING]
+```
+
+## Example
+
+A quick audit of the `usr/src/bin/echo` directory:
+
+```bash
+python3 scripts/scan-includes.py usr/src/bin/echo \
+  -I usr/include -I usr/src/include -I usr/src/lib/libc/include
+```
+
+```text
+usr/src/bin/echo/echo.c -> stdio.h [ok]
+```
+
+This indicates all local headers resolve correctly for that component.
+
+## Machine-Readable Output
+
+For automated tooling, a structured JSON report can be generated:
+
+```bash
+python3 scripts/scan-includes.py usr/src/bin/echo \
+  -I usr/include -I usr/src/include -I usr/src/lib/libc/include \
+  --json
+```
+
+Each entry in the resulting array records the source file, header, and
+resolution status, facilitating downstream analysis.
+
+## CMake Integration
+
+To drive the audit from the build system, configure CMake to emit
+`compile_commands.json` and invoke the dedicated target:
+
+```bash
+cmake -S . -B build -G Ninja \
+  -DCMAKE_C_COMPILER=$(command -v clang) \
+  -DCMAKE_LINKER=$(command -v lld) \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+ninja -C build include-audit
+```
+
+The custom target delegates to `scan-includes.py` using the generated
+`compile_commands.json` for include discovery, ensuring the audit mirrors
+the active build configuration.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,5 +5,7 @@
    :maxdepth: 2
 
    codebase-segmentation
+   include-audit
+   reproducible-build
 
 .. doxygenfile:: proc.c

--- a/docs/reproducible-build.md
+++ b/docs/reproducible-build.md
@@ -1,0 +1,42 @@
+# Reproducible Build Environment
+
+This guide captures a known-good configuration for building and auditing
+this codebase. Commands are intended to be reproducible on recent
+Debian-based distributions.
+
+## Dependencies
+
+```bash
+apt-get update
+apt-get install -y \\
+  clang lld cmake ninja-build python3 python3-pip \\
+  graphviz doxygen bmake
+pip3 install sphinx myst-parser
+```
+
+## Configure and Build
+
+```bash
+cmake -S . -B build -G Ninja \
+  -DCMAKE_C_COMPILER=$(command -v clang) \
+  -DCMAKE_LINKER=$(command -v lld) \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+ninja -C build
+```
+
+## Audit Headers
+
+```bash
+ninja -C build include-audit
+```
+
+## Documentation
+
+```bash
+./tests/test_docs.sh
+./tests/test_include_audit.sh
+./tests/test_kernel.sh
+```
+
+These steps establish a repeatable baseline for further experimentation.

--- a/scripts/scan-includes.py
+++ b/scripts/scan-includes.py
@@ -1,39 +1,147 @@
 #!/usr/bin/env python3
-"""Recursively scan source files for #include directives."""
+"""Recursively scan source files for ``#include`` directives.
+
+The utility walks a source tree, collects all ``#include`` statements
+and optionally verifies that the referenced headers exist. This helps
+audit historic code for stale or missing dependencies.
+"""
 from __future__ import annotations
 
-import collections
+import argparse
+import json
 import os
 import re
+import shlex
 import sys
-from typing import DefaultDict, Set
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import DefaultDict, Dict, Iterable, List, Set
 
 INC_RE = re.compile(r'^\s*#\s*include\s*[<"]([^">]+)[">]')
 
-def walk_sources(root: str) -> DefaultDict[str, Set[str]]:
-    graph: DefaultDict[str, Set[str]] = collections.defaultdict(set)
+
+@dataclass
+class IncludeEntry:
+    """Record of a single ``#include`` reference."""
+
+    source: Path
+    header: str
+    found: bool
+
+
+def walk_sources(root: Path) -> DefaultDict[Path, Set[str]]:
+    """Return a mapping of source paths to the headers they include."""
+
+    graph: DefaultDict[Path, Set[str]] = defaultdict(set)
+    root = root.resolve()
     for dirpath, _, files in os.walk(root):
         for name in files:
-            if not name.endswith(('.c', '.h', '.S', '.s')):
+            if not name.endswith((".c", ".h", ".S", ".s")):
                 continue
-            path = os.path.join(dirpath, name)
+            path = Path(dirpath, name).resolve()
             try:
-                with open(path, 'r', errors='ignore') as fh:
+                with open(path, "r", errors="ignore") as fh:
                     for line in fh:
-                        m = INC_RE.match(line)
-                        if m:
-                            graph[path].add(m.group(1))
+                        match = INC_RE.match(line)
+                        if match:
+                            graph[path].add(match.group(1))
             except OSError:
+                # Skip files that cannot be read
                 pass
     return graph
 
-def main(argv: list[str]) -> int:
-    root = argv[1] if len(argv) > 1 else '.'
-    graph = walk_sources(root)
-    for src in sorted(graph):
-        for hdr in sorted(graph[src]):
-            print(f"{src} -> {hdr}")
-    return 0
 
-if __name__ == '__main__':
+def header_exists(header: str, search_dirs: Iterable[Path]) -> bool:
+    """Return True if ``header`` is found in ``search_dirs``."""
+
+    return any((d / header).exists() for d in search_dirs)
+
+
+def parse_compile_commands(path: str) -> Dict[Path, List[Path]]:
+    """Parse ``compile_commands.json`` mapping sources to include directories."""
+
+    mapping: Dict[Path, List[Path]] = {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            database = json.load(fh)
+    except OSError:
+        return mapping
+
+    for entry in database:
+        directory = Path(entry.get("directory", ".")).resolve()
+        source = (directory / entry.get("file", "")).resolve()
+        args = entry.get("arguments")
+        if args is None:
+            args = shlex.split(entry.get("command", ""))
+        includes: List[Path] = []
+        it = iter(args)
+        for token in it:
+            if token == "-I":
+                includes.append((directory / next(it, "")).resolve())
+            elif token.startswith("-I"):
+                includes.append((directory / token[2:]).resolve())
+        mapping[source] = includes
+    return mapping
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", default=".", help="root directory to scan")
+    parser.add_argument(
+        "-I",
+        "--include-dir",
+        dest="includes",
+        action="append",
+        default=[],
+        help="additional include directories for header resolution",
+    )
+    parser.add_argument(
+        "--missing-only", action="store_true", help="print only missing headers"
+    )
+    parser.add_argument(
+        "--compile-commands",
+        help="path to compile_commands.json for include discovery",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit machine-readable JSON report"
+    )
+    args = parser.parse_args(argv[1:])
+
+    graph = walk_sources(Path(args.root))
+    search_dirs = [Path(p).resolve() for p in args.includes]
+    compile_map = (
+        parse_compile_commands(args.compile_commands) if args.compile_commands else {}
+    )
+
+    entries: List[IncludeEntry] = []
+    root_abs = Path(args.root).resolve()
+    for src in sorted(graph):
+        includes = search_dirs + compile_map.get(src, [])
+        for hdr in sorted(graph[src]):
+            found = header_exists(hdr, includes)
+            if args.missing_only and found:
+                continue
+            try:
+                rel_src = src.relative_to(root_abs)
+            except ValueError:
+                rel_src = src
+            entries.append(IncludeEntry(source=rel_src, header=hdr, found=found))
+
+    if args.json:
+        payload = [
+            {"source": str(e.source), "header": e.header, "found": e.found}
+            for e in entries
+        ]
+        print(json.dumps(payload, indent=2))
+    else:
+        for e in entries:
+            status = "ok" if e.found else "MISSING"
+            print(f"{e.source} -> {e.header} [{status}]")
+
+    missing = any(not e.found for e in entries)
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
     raise SystemExit(main(sys.argv))

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 3.16)
 # toolchain file supplies the cross-compilation and linker flags.
 add_executable(hello hello.c)
 
+# Build a freestanding binary with no implicit runtime.
+target_compile_options(hello PRIVATE -ffreestanding -fno-builtin)
+target_link_options(hello PRIVATE -nostdlib -Wl,-e,_start)
+
 # Produce an ELF binary with a distinctive suffix to avoid
 # confusion with host executables.
 set_target_properties(hello PROPERTIES OUTPUT_NAME "hello.elf")

--- a/tests/test_include_audit.sh
+++ b/tests/test_include_audit.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Verify the include-audit utility resolves headers for a simple component.
+set -e
+python3 scripts/scan-includes.py usr/src/bin/echo \
+  -I usr/include -I usr/src/include -I usr/src/lib/libc/include \
+  --compile-commands build/compile_commands.json \
+  --json > /tmp/include_audit.json
+# Ensure output is valid JSON by invoking python's json.tool
+python3 -m json.tool < /tmp/include_audit.json > /dev/null


### PR DESCRIPTION
## Summary
- extend `scan-includes.py` with dataclass-based reporting and a `--json` flag for machine-readable results
- document the JSON workflow and broaden reproducible build instructions with required packages and verification scripts
- add a smoke test that validates JSON output from the include auditor

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=$(command -v clang) -DCMAKE_LINKER=$(command -v lld) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `ninja -C build`
- `ninja -C build include-audit` *(fails: multiple headers missing)*
- `./tests/test_include_audit.sh`
- `./tests/test_docs.sh` *(succeeds with warnings)*
- `./tests/test_kernel.sh` *(warns: kernel image absent)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c4630c4483319c55c64809453286