### PR TITLE
Add unused-header detection to audit tool

### DIFF
--- a/docs/header-audit.md
+++ b/docs/header-audit.md
@@ -1,0 +1,83 @@
+# Header Audit Utility
+
+The project includes `scripts/header_audit.py`, a small helper that scans the
+source tree for local `#include "..."` directives and reports headers that are
+referenced but absent. When invoked with the `--unused` flag it also lists header
+files present on disk yet never included, aiding reconciliation of the sources
+with the expectations of the build system.
+
+## Usage
+
+```bash
+python scripts/header_audit.py [path] [--unused] [--json] [--strict]
+```
+
+The optional `path` argument specifies the root directory to examine. When
+omitted, the current working directory is scanned. The script searches for C,
+header, and assembly sources and emits reports such as:
+
+```
+Missing headers detected:
+usr/src/foo/bar.c: includes 'missing.h' not found
+```
+
+If every include can be resolved, the tool prints `No missing local headers
+found.` When `--unused` is supplied an additional section lists headers that are
+never referenced:
+
+```
+Unused headers:
+usr/include/legacy/foo.h
+```
+
+### JSON output and strict mode
+
+For machine consumption or continuous‑integration jobs the auditor can emit a
+structured JSON report and fail the build when problems are discovered:
+
+```bash
+# Produce JSON and exit with code 1 if issues are found
+python scripts/header_audit.py --unused --json --strict > audit.json
+```
+
+The JSON schema contains two top‑level arrays:
+
+```json
+{
+  "missing": [{"source": "path/to/file.c", "header": "foo.h"}],
+  "unused": ["path/to/obsolete.h"]
+}
+```
+
+### Ignoring system headers
+
+Many historical sources use quoted includes for operating‑system headers such as
+`"sys/param.h"`. The auditor suppresses common system headers by default, but
+additional patterns can be ignored via the `--ignore` (or `-i`) flag. Patterns
+use the same wildcard syntax as Unix shells:
+
+```bash
+# Ignore anything under contrib/ and a custom foo.h
+python scripts/header_audit.py -i 'contrib/*' -i foo.h
+```
+
+Patterns are matched against the raw include string (e.g. `sys/param.h`).
+Internally, the default ignore list already covers typical standard library and
+kernel headers.
+
+## Environment
+
+The utility requires only the standard Python 3 runtime. For reproducible
+results in this repository, install the documentation toolchain and BSD make
+as outlined in [`setup.md`](../setup.md):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y doxygen bmake
+pip install sphinx breathe sphinx-rtd-theme
+```
+
+Running `./tests/test_docs.sh` verifies the documentation build, while
+`./tests/test_kernel.sh` performs a lightweight kernel build smoke test. These
+checks were executed during development of this script to ensure the environment
+was configured correctly.

--- a/scripts/header_audit.py
+++ b/scripts/header_audit.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Audit the tree for missing and unused local ``#include`` directives.
+
+The auditor traverses the source tree rooted at ``root`` and inspects C and
+assembly files for directives of the form ``#include "path"``. Each quoted
+header is resolved relative to the including file and repository root. Missing
+headers that do not match a known system pattern are reported. Optionally, the
+utility can also flag *unused* headers that exist on disk but are never
+referenced by any source file in the scan.
+
+Example usage::
+
+    # report both missing and unused local headers
+    python scripts/header_audit.py path/to/tree --unused
+
+Additional include patterns can be ignored via ``--ignore`` options. Patterns
+use Unix shell wildcards as understood by :mod:`fnmatch`.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Match lines like: #include "foo.h"
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s+"([^"\n]+)"')
+
+# Common system header prefixes or names that should be ignored by default.
+DEFAULT_IGNORES = {
+    "sys/*",
+    "machine/*",
+    "net/*",
+    "ufs/*",
+    "vm/*",
+    "X*",
+    "xf86*",
+    "errno.h",
+    "stddef.h",
+    "stdint.h",
+    "stdio.h",
+    "stdlib.h",
+    "string.h",
+    "time.h",
+    "unistd.h",
+    "malloc.h",
+}
+
+
+@dataclass
+class AuditResult:
+    """Structured representation of audit findings."""
+
+    missing: list[tuple[str, Path]]
+    unused: list[Path]
+
+
+def should_ignore(header: str, patterns: set[str]) -> bool:
+    """Return ``True`` if *header* matches any pattern in *patterns*.
+
+    Pattern semantics follow :func:`fnmatch.fnmatch` and therefore accept
+    wildcards such as ``sys/*``.
+    """
+
+    return any(fnmatch.fnmatch(header, pat) for pat in patterns)
+
+
+def audit(root: Path, ignore: set[str]) -> tuple[list[tuple[str, Path]], set[Path]]:
+    """Return unresolved includes and the set of resolved headers.
+
+    Parameters
+    ----------
+    root:
+        Root directory of the source tree to scan.
+    ignore:
+        ``fnmatch`` patterns specifying headers to skip.
+
+    Returns
+    -------
+    missing:
+        List of tuples ``(header, source)`` for includes that could not be
+        resolved relative to *root*.
+    referenced:
+        Set of header :class:`Path` objects that were successfully resolved and
+        therefore referenced by at least one source file.
+    """
+
+    missing: list[tuple[str, Path]] = []
+    referenced: set[Path] = set()
+
+    for path in root.rglob("*"):
+        if path.suffix.lower() not in {".c", ".h", ".s", ".S"}:
+            continue
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            m = INCLUDE_RE.match(line)
+            if not m:
+                continue
+            inc = m.group(1)
+            if should_ignore(inc, ignore):
+                continue
+            candidates = [path.parent / inc, root / inc]
+            found = False
+            for candidate in candidates:
+                if candidate.exists():
+                    try:
+                        rel = candidate.resolve().relative_to(root.resolve())
+                    except ValueError:
+                        continue
+                    referenced.add(rel)
+                    found = True
+                    break
+            if not found:
+                missing.append((inc, path))
+
+    return missing, referenced
+
+
+def find_unused(root: Path, referenced: set[Path], ignore: set[str]) -> list[Path]:
+    """Return headers under *root* that are never referenced."""
+
+    unused: list[Path] = []
+    for header in root.rglob("*.h"):
+        try:
+            rel = header.resolve().relative_to(root.resolve())
+        except ValueError:
+            continue
+        if should_ignore(str(rel), ignore):
+            continue
+        if rel not in referenced:
+            unused.append(rel)
+    return unused
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit local header includes")
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default=Path.cwd(),
+        type=Path,
+        help="Root of tree to scan",
+    )
+    parser.add_argument(
+        "--ignore",
+        "-i",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="Additional fnmatch patterns to ignore",
+    )
+    parser.add_argument(
+        "--unused",
+        "-u",
+        action="store_true",
+        help="Report headers present on disk but never included",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as JSON for machine consumption",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return exit status 1 if issues are found",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    ignore: set[str] = DEFAULT_IGNORES | set(args.ignore)
+    missing, referenced = audit(args.root, ignore)
+    unused: list[Path] = []
+    if args.unused:
+        unused = find_unused(args.root, referenced, ignore)
+
+    result = AuditResult(missing=missing, unused=unused)
+
+    if args.json:
+        payload = {
+            "missing": [
+                {"source": str(src), "header": inc} for inc, src in result.missing
+            ],
+            "unused": [str(hdr) for hdr in sorted(result.unused)],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        if result.missing:
+            print("Missing headers detected:")
+            for inc, src in result.missing:
+                print(f"{src}: includes '{inc}' not found")
+        else:
+            print("No missing local headers found.")
+        if args.unused:
+            if result.unused:
+                print("\nUnused headers:")
+                for hdr in sorted(result.unused):
+                    print(hdr)
+            else:
+                print("\nNo unused headers detected.")
+
+    if args.strict and (result.missing or result.unused):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- detect and report headers that exist but are never included
- document `--unused` flag and environment setup for reproducibility
- emit machine-readable JSON with `--json` and fail-on-issues mode via `--strict`

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y doxygen bmake`
- `pip install sphinx breathe sphinx-rtd-theme black`
- `./tests/test_docs.sh`
- `./tests/test_kernel.sh`
- `python scripts/header_audit.py scripts --unused --json`

------
https://chatgpt.com/codex/tasks/task_e_68a7c4fa34748331a3e7e86e66f530a4